### PR TITLE
Add option to configure LB stickiness

### DIFF
--- a/fleet/gateway.tf
+++ b/fleet/gateway.tf
@@ -48,6 +48,12 @@ resource "aws_lb_target_group" "gateway" {
   protocol = "HTTP"
   vpc_id   = "${var.vpc_id}"
 
+  stickiness {
+    enabled = "${var.lb_stickiness_enabled}"
+    type = "lb_cookie"
+    cookie_duration = "${var.lb_stickiness_cookie_duration}"
+  }
+
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2

--- a/fleet/variables.tf
+++ b/fleet/variables.tf
@@ -55,3 +55,11 @@ variable "gateway_dns" {
 variable "user_data_file" {}
 
 variable "spot_user_data_file" {}
+
+variable "lb_stickiness_enabled" {
+  default = false
+}
+
+variable "lb_stickiness_cookie_duration" {
+  default = 86400
+}


### PR DESCRIPTION
To be able to use websockets, sticky load balancer sessions needs to be enabled.

in scope of https://www.pivotaltracker.com/story/show/164978300

https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#sticky-sessions