### PR TITLE
Fix: Expose fleet submodule vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,9 @@ module "aws_fleet" {
   additional_storage      = "${var.additional_storage}"
   additional_storage_size = "${var.additional_storage_size}"
 
+  lb_stickiness_enabled         = "${var.lb_stickiness_enabled}"
+  lb_stickiness_cookie_duration = "${var.lb_stickiness_cookie_duration}"
+
   aeternity = "${var.aeternity}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -79,3 +79,12 @@ variable "user_data_file" {
 variable "spot_user_data_file" {
   default = "user_data.bash"
 }
+
+# Exopose fleet module vars
+variable "lb_stickiness_enabled" {
+  default = false
+}
+
+variable "lb_stickiness_cookie_duration" {
+  default = 86400
+}


### PR DESCRIPTION
We need to implicitly define the variables used by the submodule, as they are not accessible in the main module.