### PR TITLE
Compatibility with terraform 0.12 of the v1.0 module

### DIFF
--- a/fleet/sg.tf
+++ b/fleet/sg.tf
@@ -20,8 +20,8 @@ resource "aws_security_group_rule" "allow_all_internal" {
   to_port   = 65535
   protocol  = "TCP"
 
-  security_group_id        = "${aws_security_group.ae-nodes.id}"
-  source_security_group_id = "${aws_security_group.ae-nodes.id}"
+  security_group_id        = "${aws_security_group.ae-nodes[0].id}"
+  source_security_group_id = "${aws_security_group.ae-nodes[0].id}"
 }
 
 resource "aws_security_group_rule" "external_api_port" {
@@ -31,7 +31,7 @@ resource "aws_security_group_rule" "external_api_port" {
   to_port           = 3015
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-nodes.id}"
+  security_group_id = "${aws_security_group.ae-nodes[0].id}"
 }
 
 resource "aws_security_group_rule" "external_healthz_port" {
@@ -41,7 +41,7 @@ resource "aws_security_group_rule" "external_healthz_port" {
   to_port           = 8080
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-nodes.id}"
+  security_group_id = "${aws_security_group.ae-nodes[0].id}"
 }
 
 resource "aws_security_group_rule" "sync_protocol_port" {
@@ -51,7 +51,7 @@ resource "aws_security_group_rule" "sync_protocol_port" {
   to_port           = 3015
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-nodes.id}"
+  security_group_id = "${aws_security_group.ae-nodes[0].id}"
 }
 
 resource "aws_security_group_rule" "allow_outgoing-node" {
@@ -61,7 +61,7 @@ resource "aws_security_group_rule" "allow_outgoing-node" {
   to_port           = 65535
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-nodes.id}"
+  security_group_id = "${aws_security_group.ae-nodes[0].id}"
 }
 
 resource "aws_security_group" "ae-nodes-management" {

--- a/fleet/sg_gateway.tf
+++ b/fleet/sg_gateway.tf
@@ -20,7 +20,7 @@ resource "aws_security_group_rule" "allow_outgoing-node-gateway" {
   to_port           = 65535
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-gateway-nodes.id}"
+  security_group_id = "${aws_security_group.ae-gateway-nodes[0].id}"
 }
 
 resource "aws_security_group_rule" "http_protocol_port" {
@@ -30,7 +30,7 @@ resource "aws_security_group_rule" "http_protocol_port" {
   to_port           = 80
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-gateway-nodes-loadbalancer.id}"
+  security_group_id = "${aws_security_group.ae-gateway-nodes-loadbalancer[0].id}"
 }
 
 resource "aws_security_group_rule" "healthz_protocol_port" {
@@ -40,7 +40,7 @@ resource "aws_security_group_rule" "healthz_protocol_port" {
   to_port           = 8080
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-gateway-nodes-loadbalancer.id}"
+  security_group_id = "${aws_security_group.ae-gateway-nodes-loadbalancer[0].id}"
 }
 
 resource "aws_security_group" "ae-gateway-nodes" {
@@ -66,7 +66,7 @@ resource "aws_security_group_rule" "allow_outgoing-node-lb" {
   to_port           = 65535
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-gateway-nodes-loadbalancer.id}"
+  security_group_id = "${aws_security_group.ae-gateway-nodes-loadbalancer[0].id}"
 }
 
 resource "aws_security_group_rule" "allow_all_internal_gateway_nodes" {
@@ -76,8 +76,8 @@ resource "aws_security_group_rule" "allow_all_internal_gateway_nodes" {
   to_port   = 65535
   protocol  = "TCP"
 
-  security_group_id        = "${aws_security_group.ae-gateway-nodes.id}"
-  source_security_group_id = "${aws_security_group.ae-gateway-nodes.id}"
+  security_group_id        = "${aws_security_group.ae-gateway-nodes[0].id}"
+  source_security_group_id = "${aws_security_group.ae-gateway-nodes[0].id}"
 }
 
 resource "aws_security_group_rule" "external_gateway_healthz_port" {
@@ -87,7 +87,7 @@ resource "aws_security_group_rule" "external_gateway_healthz_port" {
   to_port           = 8080
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-gateway-nodes.id}"
+  security_group_id = "${aws_security_group.ae-gateway-nodes[0].id}"
 }
 
 resource "aws_security_group_rule" "external_sync_port" {
@@ -97,7 +97,7 @@ resource "aws_security_group_rule" "external_sync_port" {
   to_port           = 3015
   protocol          = "TCP"
   cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.ae-gateway-nodes.id}"
+  security_group_id = "${aws_security_group.ae-gateway-nodes[0].id}"
 }
 
 resource "aws_security_group_rule" "external_api_port_lb" {
@@ -106,6 +106,6 @@ resource "aws_security_group_rule" "external_api_port_lb" {
   from_port                = 3013
   to_port                  = 3013
   protocol                 = "TCP"
-  security_group_id        = "${aws_security_group.ae-gateway-nodes.id}"
-  source_security_group_id = "${aws_security_group.ae-gateway-nodes-loadbalancer.id}"
+  security_group_id        = "${aws_security_group.ae-gateway-nodes[0].id}"
+  source_security_group_id = "${aws_security_group.ae-gateway-nodes-loadbalancer[0].id}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 module "aws_vpc" {
-  source = "vpc"
+  source = "./vpc"
   env    = "${var.env}"
 }
 
 module "aws_fleet" {
-  source              = "fleet"
+  source              = "./fleet"
   color               = "${var.color}"
   env                 = "${var.env}"
   bootstrap_version   = "${var.bootstrap_version}"
@@ -44,13 +44,13 @@ output "gateway_lb_zone_id" {
   value = "${module.aws_fleet.gateway_lb_zone_id}"
 }
 
-# Module to module depens_on workaround
+# Module to module dependency workaround
 # See https://github.com/hashicorp/terraform/issues/1178#issuecomment-105613781
 # See https://github.com/hashicorp/terraform/issues/10462#issuecomment-285751349
 # See https://github.com/hashicorp/terraform/issues/17101
 resource "null_resource" "dummy_dependency" {
-  triggers {
-    depends_on = "${join(",", var.depends_on)}"
+  triggers = {
+    depends_on = "${join(",", var.dependency)}"
   }
 }
 

--- a/test/test.tf
+++ b/test/test.tf
@@ -19,7 +19,7 @@ variable "package" {
 }
 
 provider "aws" {
-  version                 = "1.55"
+  version                 = "2.19"
   region                  = "ap-southeast-2"
   alias                   = "ap-southeast-2"
   shared_credentials_file = "/aws/credentials"

--- a/variables.tf
+++ b/variables.tf
@@ -42,14 +42,14 @@ variable "aeternity" {
   type = "map"
 }
 
-# Module to module depens_on workaround
+# Module to module dependency workaround
 # See https://github.com/hashicorp/terraform/issues/1178#issuecomment-105613781
 # See https://github.com/hashicorp/terraform/issues/10462#issuecomment-285751349
 # See https://github.com/hashicorp/terraform/issues/17101
-variable "depends_on" {
+variable "dependency" {
   default = []
 
-  type = "list"
+  type = list(string)
 }
 
 variable "ami_name" {}


### PR DESCRIPTION
This is a BC branch of v1.0 that is compatible with Terraform 0.12 as a temporary workaround.
However other modules that rely on 1.0.x might need small update. E.g. `var.depends_on` had to be renamed to `var.dependency`, because it is introduced as reserved word. Also it have to be list of strings (or could be casted to it). Terraform 0.12 also does not dynamically flatten lists, so [['a']] is no longer identical to ['a']

This should not merge