### PR TITLE
Autoscaling group tags do not allow empty values for tags (envid tag)

### DIFF
--- a/fleet/main.tf
+++ b/fleet/main.tf
@@ -33,7 +33,7 @@ resource "aws_instance" "static_node" {
   tags = {
     Name              = "ae-${var.env}-static-node"
     env               = "${var.env}"
-    envid             = "${var.envid}"
+    envid             = var.envid
     role              = "aenode"
     color             = "${var.color}"
     kind              = "seed"
@@ -173,7 +173,7 @@ resource "aws_autoscaling_group" "spot_fleet" {
     },
     {
       key                 = "envid"
-      value               = "${var.envid}"
+      value               = var.envid
       propagate_at_launch = true
     },
     {

--- a/fleet/main.tf
+++ b/fleet/main.tf
@@ -173,7 +173,7 @@ resource "aws_autoscaling_group" "spot_fleet" {
     },
     {
       key                 = "envid"
-      value               = var.envid
+      value               = coalesce(var.envid, var.env)
       propagate_at_launch = true
     },
     {


### PR DESCRIPTION
Seems like after update to terraform 0.12 `aws_autoscaling_group` no longer accepts empty strings for values. Builds do not set this environment (it is used by tests) and they fail.