### PR TITLE
Allow passing 'node_config' from root module

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -78,3 +78,7 @@ variable asg_target_groups {
 variable snapshot_filename {
   default = "empty"
 }
+
+variable "node_config" {
+  default = ""
+}


### PR DESCRIPTION
It just allows to override the resolving of the 'vault config key' from the other modules.
Allows node to be setup with `env@region` for instance.

Had to be done in the previous version