### PR TITLE
 lock aeternity/infrastructure image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   infrastructure_container:
     docker:
-      - image: aeternity/infrastructure
+      - image: aeternity/infrastructure:v2.12.3
     working_directory: /src
 
 commands:

--- a/test/test.tf
+++ b/test/test.tf
@@ -14,7 +14,7 @@ module "aws_deploy-test" {
 
   spot_price    = "0.04"
   instance_type = "t3.large"
-  ami_name      = "aeternity-ubuntu-16.04-*"
+  ami_name      = "aeternity-ubuntu-18.04-*"
 
   additional_storage      = true
   additional_storage_size = 5


### PR DESCRIPTION
lock caused by backward incompatible terraform version changes