### PR TITLE
[Breaking] Optimize configuration and allow optimization configs

### DIFF
--- a/fleet/main.tf
+++ b/fleet/main.tf
@@ -1,7 +1,7 @@
 locals {
   autoscale_enabled = var.spot_nodes_max > var.spot_nodes_min
-  node_config       = coalesce(var.node_config, "secret/aenode/config/${var.env}")
   user_data         = templatefile("${path.module}/templates/${var.user_data_file}", {})
+  instance_types = concat([var.instance_type], var.instance_types)
 }
 
 data "aws_region" "current" {}
@@ -18,43 +18,21 @@ data "aws_ami" "ami" {
 }
 
 resource "aws_instance" "static_node" {
-  count                = var.static_nodes
-  ami                  = data.aws_ami.ami.id
-  instance_type        = var.instance_type
-  iam_instance_profile = "ae-node"
-
-  root_block_device {
-    volume_type = "gp3"
-    volume_size = var.root_volume_size
-    iops        = var.root_volume_iops
-    throughput  = var.root_volume_throughput
-  }
-
-  tags = {
-    Name              = "ae-${var.env}-static-node"
-    env               = var.env
-    node_config       = local.node_config
-    envid             = var.envid
-    role              = "aenode"
-    color             = var.color
-    kind              = coalesce(var.kind, "seed")
-    bootstrap_version = var.bootstrap_version
-    vault_addr        = var.vault_addr
-    vault_role        = var.vault_role
-  }
-
-  user_data = local.user_data
-
+  count = var.static_nodes
   subnet_id = element(var.subnets, 1)
 
-  vpc_security_group_ids = [
-    aws_security_group.ae-nodes.id,
-    aws_security_group.ae-nodes-management.id,
-  ]
+  launch_template {
+    id = aws_launch_template.fleet.id
+    version = "$Latest"
+  }
 
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = merge(var.tags, var.config_tags, {
+    Name  = "ae-${var.tags.env}-static-node",
+  })
 }
 
 resource "aws_lb_target_group_attachment" "static_node" {
@@ -63,97 +41,79 @@ resource "aws_lb_target_group_attachment" "static_node" {
   target_id        = element(aws_instance.static_node.*.id, count.index)
 }
 
-resource "aws_ebs_volume" "ebs" {
-  count             = var.additional_storage ? var.static_nodes : 0
-  availability_zone = element(aws_instance.static_node.*.availability_zone, count.index)
-  type              = "gp3"
-  size              = var.additional_storage_size
-  iops              = var.additional_storage_iops
-  throughput        = var.additional_storage_throughput
+resource "aws_launch_template" "fleet" {
+  name_prefix   = "ae-${var.env}-tpl-"
+  image_id      = data.aws_ami.ami.id
+  instance_type = var.instance_type
+  user_data     = base64encode(local.user_data)
+  ebs_optimized = true
 
-  tags = {
-    Name = "ae-${var.env}-static-node"
-    env  = var.env
-  }
-}
-
-resource "aws_volume_attachment" "ebs_att" {
-  count       = var.additional_storage ? var.static_nodes : 0
-  device_name = "/dev/sdh"
-  volume_id   = element(aws_ebs_volume.ebs.*.id, count.index)
-  instance_id = element(aws_instance.static_node.*.id, count.index)
-}
-
-resource "aws_launch_configuration" "spot" {
-  count                = var.spot_nodes_min > 0 ? 1 : 0
-  name_prefix          = "ae-${var.env}-spot-nodes-"
-  iam_instance_profile = "ae-node"
-  image_id             = data.aws_ami.ami.id
-  instance_type        = var.instance_type
-  spot_price           = var.spot_price
-
-  security_groups = [
+  vpc_security_group_ids = [
     aws_security_group.ae-nodes.id,
     aws_security_group.ae-nodes-management.id,
   ]
 
-  root_block_device {
-    volume_type = "gp3"
-    volume_size = var.root_volume_size
-    iops        = var.root_volume_iops
-    throughput  = var.root_volume_throughput
+  iam_instance_profile {
+    name = "ae-node"
   }
 
-  lifecycle {
-    create_before_destroy = true
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_type           = "gp3"
+      volume_size           = var.root_volume_size
+      iops                  = var.root_volume_iops
+      throughput            = var.root_volume_throughput
+      delete_on_termination = true
+    }
   }
 
-  user_data = local.user_data
-}
+  dynamic "block_device_mappings" {
+    for_each = var.additional_storage ? [1] : []
+    content {
+      device_name = "/dev/sdh"
 
-resource "aws_launch_configuration" "spot-with-additional-storage" {
-  count                = var.spot_nodes_min > 0 ? 1 : 0
-  name_prefix          = "ae-${var.env}-spot-nodes-"
-  iam_instance_profile = "ae-node"
-  image_id             = data.aws_ami.ami.id
-  instance_type        = var.instance_type
-  spot_price           = var.spot_price
-
-  security_groups = [
-    aws_security_group.ae-nodes.id,
-    aws_security_group.ae-nodes-management.id,
-  ]
-
-  root_block_device {
-    volume_type = "gp3"
-    volume_size = var.root_volume_size
-    iops        = var.root_volume_iops
-    throughput  = var.root_volume_throughput
+      ebs {
+        volume_type           = "gp3"
+        volume_size           = var.additional_storage_size
+        iops                  = var.additional_storage_iops
+        throughput            = var.additional_storage_throughput
+        delete_on_termination = true
+      }
+    }
   }
 
-  ebs_block_device {
-    device_name = "/dev/sdh"
-    volume_type = "gp3"
-    volume_size = var.additional_storage_size
-    iops        = var.additional_storage_iops
-    throughput  = var.additional_storage_throughput
+  dynamic "monitoring" {
+    for_each = local.autoscale_enabled ? [1] : []
+    content {
+      enabled = true
+    }
   }
 
-  lifecycle {
-    create_before_destroy = true
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(var.tags, var.config_tags, {
+      Name  = "ae-${var.tags.env}-node",
+    })
   }
 
-  user_data = local.user_data
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(var.tags, {
+      Name  = "ae-${var.tags.env}-node-vol",
+    })
+  }
 }
 
 resource "aws_autoscaling_group" "spot_fleet" {
-  count                = var.spot_nodes_min > 0 ? 1 : 0
-  name_prefix          = "ae-${var.env}-spot-nodes-"
-  min_size             = max(var.spot_nodes_min, var.spot_nodes)
-  max_size             = max(var.spot_nodes_max, var.spot_nodes)
-  launch_configuration = var.additional_storage ? aws_launch_configuration.spot-with-additional-storage.0.name : aws_launch_configuration.spot.0.name
-  vpc_zone_identifier  = var.subnets
-  target_group_arns    = var.asg_target_groups
+  count               = var.spot_nodes_min > 0 ? 1 : 0
+  name_prefix         = "ae-${var.env}-spot-nodes-"
+  min_size            = max(var.spot_nodes_min, var.spot_nodes)
+  max_size            = max(var.spot_nodes_max, var.spot_nodes)
+  capacity_rebalance  = true
+  vpc_zone_identifier = var.subnets
+  target_group_arns   = var.asg_target_groups
 
   enabled_metrics = local.autoscale_enabled ? [
     "GroupMinSize",
@@ -166,120 +126,50 @@ resource "aws_autoscaling_group" "spot_fleet" {
     "GroupTotalInstances",
   ] : []
 
+  mixed_instances_policy {
+    instances_distribution {
+      on_demand_base_capacity                  = 0
+      on_demand_percentage_above_base_capacity = 0
+      spot_allocation_strategy                 = "capacity-optimized"
+    }
+
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.fleet.id
+        version            = "$Latest"
+      }
+
+      dynamic "override" {
+        for_each = toset(local.instance_types)
+        content {
+          instance_type = override.key
+        }
+      }
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }
 
-  tags = [
-    {
-      key                 = "Name"
-      value               = "ae-${var.env}-nodes"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "kind"
-      value               = coalesce(var.kind, "peer")
-      propagate_at_launch = true
-    },
-    {
-      key                 = "env"
-      value               = var.env
-      propagate_at_launch = true
-    },
-    {
-      key                 = "node_config"
-      value               = local.node_config
-      propagate_at_launch = true
-    },
-    {
-      key                 = "envid"
-      value               = coalesce(var.envid, var.env)
-      propagate_at_launch = true
-    },
-    {
-      key                 = "role"
-      value               = "aenode"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "color"
-      value               = var.color
-      propagate_at_launch = true
-    },
-    {
-      key                 = "bootstrap_version"
-      value               = var.bootstrap_version
-      propagate_at_launch = true
-    },
-    {
-      key                 = "vault_addr"
-      value               = var.vault_addr
-      propagate_at_launch = true
-    },
-    {
-      key                 = "vault_role"
-      value               = var.vault_role
-      propagate_at_launch = true
-    },
-  ]
-}
-
-resource "aws_autoscaling_policy" "gateway-cpu-policy-up" {
-  count                  = local.autoscale_enabled ? 1 : 0
-  name                   = "ae-${var.env}-cpu-up"
-  autoscaling_group_name = aws_autoscaling_group.spot_fleet.0.name
-  adjustment_type        = "ChangeInCapacity"
-  scaling_adjustment     = "1"
-  cooldown               = "300"
-  policy_type            = "SimpleScaling"
-}
-
-resource "aws_autoscaling_policy" "gateway-cpu-policy-down" {
-  count                  = local.autoscale_enabled ? 1 : 0
-  name                   = "ae-${var.env}-cpu-down"
-  autoscaling_group_name = aws_autoscaling_group.spot_fleet.0.name
-  adjustment_type        = "ChangeInCapacity"
-  scaling_adjustment     = "-1"
-  cooldown               = "300"
-  policy_type            = "SimpleScaling"
-}
-
-resource "aws_cloudwatch_metric_alarm" "gateway-cpu-alarm-up" {
-  count               = local.autoscale_enabled ? 1 : 0
-  alarm_name          = "ae-${var.env}-cpu-alarm-up"
-  alarm_description   = "cpu-alarm-up"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/EC2"
-  period              = "120"
-  statistic           = "Average"
-  threshold           = "70"
-
-  dimensions = {
-    "AutoScalingGroupName" = aws_autoscaling_group.spot_fleet.0.name
+  tag {
+    key                 = "kind"
+    value               = "peer"
+    propagate_at_launch = true
   }
-
-  actions_enabled = true
-  alarm_actions   = aws_autoscaling_policy.gateway-cpu-policy-up.*.arn
 }
 
-resource "aws_cloudwatch_metric_alarm" "gateway-cpu-alarm-down" {
-  count               = local.autoscale_enabled ? 1 : 0
-  alarm_name          = "ae-${var.env}-cpu-alarm-down"
-  alarm_description   = "cpu-alarm-down"
-  comparison_operator = "LessThanOrEqualToThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/EC2"
-  period              = "120"
-  statistic           = "Average"
-  threshold           = "50"
+resource "aws_autoscaling_policy" "example" {
+  count                  = local.autoscale_enabled ? 1 : 0
+  name                   = "ae-${var.env}-capacity"
+  autoscaling_group_name = aws_autoscaling_group.spot_fleet.0.name
+  policy_type            = "TargetTrackingScaling"
 
-  dimensions = {
-    "AutoScalingGroupName" = aws_autoscaling_group.spot_fleet.0.name
+  target_tracking_configuration {
+    predefined_metric_specification {
+      predefined_metric_type = "ASGAverageCPUUtilization"
+    }
+
+    target_value = 50.0
   }
-
-  actions_enabled = true
-  alarm_actions   = aws_autoscaling_policy.gateway-cpu-policy-down.*.arn
 }

--- a/fleet/variables.tf
+++ b/fleet/variables.tf
@@ -25,19 +25,15 @@ variable "additional_storage_size" {}
 variable "additional_storage_iops" {}
 variable "additional_storage_throughput" {}
 
-variable "color" {}
-
 variable "env" {}
 
-variable "envid" {
-  default = ""
+variable "instance_type" {
+  description = "Fleet insance type. Deprecated: Use instance_types."
 }
 
-variable "bootstrap_version" {}
-
-variable "instance_type" {}
-
-variable "spot_price" {}
+variable "instance_types" {
+  type = list(string)
+}
 
 variable "vpc_id" {}
 
@@ -46,10 +42,6 @@ variable "subnets" {
 }
 
 variable "ami_name" {}
-
-variable "vault_addr" {}
-
-variable "vault_role" {}
 
 variable "user_data_file" {}
 
@@ -67,10 +59,10 @@ variable "asg_target_groups" {
   type = list(any)
 }
 
-variable "node_config" {
-  default = ""
+variable "tags" {
+  type = map(string)
 }
 
-variable "kind" {
-  default = ""
+variable "config_tags" {
+  type = map(string)
 }

--- a/main.tf
+++ b/main.tf
@@ -5,40 +5,34 @@ module "aws_vpc" {
 
 module "aws_fleet" {
   source = "./fleet"
-  color  = var.color
   env    = var.env
-  envid  = var.envid
-  kind   = var.kind
 
   vpc_id  = var.vpc_id != "" ? var.vpc_id : module.aws_vpc.vpc_id
   subnets = length(var.subnets) != 0 ? var.subnets : module.aws_vpc.subnets
 
-  instance_type = var.instance_type
-  ami_name      = var.ami_name
-  spot_price    = var.spot_price
+  instance_type  = var.instance_type
+  instance_types = var.instance_types
+  ami_name       = var.ami_name
 
-  vault_addr = var.vault_addr
-  vault_role = var.vault_role
-
-  node_config = var.node_config
-
-  bootstrap_version = var.bootstrap_version
-  user_data_file    = var.user_data_file
+  user_data_file = var.user_data_file
 
   static_nodes   = var.static_nodes
   spot_nodes     = var.spot_nodes
   spot_nodes_min = var.spot_nodes_min
   spot_nodes_max = var.spot_nodes_max
 
-  root_volume_size        = var.root_volume_size
-  root_volume_iops        = var.root_volume_iops
-  root_volume_throughput  = var.root_volume_throughput
-  additional_storage      = var.additional_storage
-  additional_storage_size = var.additional_storage_size
-  additional_storage_iops = var.additional_storage_iops
+  root_volume_size              = var.root_volume_size
+  root_volume_iops              = var.root_volume_iops
+  root_volume_throughput        = var.root_volume_throughput
+  additional_storage            = var.additional_storage
+  additional_storage_size       = var.additional_storage_size
+  additional_storage_iops       = var.additional_storage_iops
   additional_storage_throughput = var.additional_storage_throughput
 
   enable_internal_api   = var.enable_internal_api
   enable_state_channels = var.enable_state_channels
   asg_target_groups     = var.asg_target_groups
+
+  tags        = var.tags
+  config_tags = var.config_tags
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "1.1.4"
   required_providers {
     aws = {
-      version = "3.74.0"
+      version = "5.12.0"
     }
     random = {
       version = "3.1.0"

--- a/test/test.tf
+++ b/test/test.tf
@@ -1,51 +1,34 @@
 module "aws_deploy-test" {
-  source            = "../"
-  env               = var.env_name
-  envid             = var.envid
-  bootstrap_version = var.bootstrap_version
-  vault_role        = "ae-node"
-  vault_addr        = var.vault_addr
-  user_data_file    = "user_data.bash"
+  source         = "../"
+  env            = var.env_name
+  user_data_file = "user_data.bash"
 
   static_nodes   = 1
   spot_nodes     = 1
   spot_nodes_min = 1
-  spot_nodes_max = 1
+  spot_nodes_max = 2
 
-  spot_price    = "0.04"
-  instance_type = "t3.large"
-  ami_name      = "aeternity-ubuntu-18.04-*"
+  instance_type  = "t3.large"
+  instance_types = ["m5.large", "r5.large"]
+  ami_name       = "aeternity-ubuntu-18.04-*"
 
   additional_storage      = true
   additional_storage_size = 5
 
   enable_state_channels = true
   enable_internal_api   = true
-}
 
-module "aws_deploy-test_vpc" {
-  source            = "../"
-  env               = var.env_name
-  envid             = var.envid
-  bootstrap_version = var.bootstrap_version
-  vault_role        = "ae-node"
-  vault_addr        = var.vault_addr
-  user_data_file    = "user_data.bash"
-  vpc_id            = module.aws_deploy-test.vpc_id
-  subnets           = module.aws_deploy-test.subnets
+  tags = {
+    env   = var.env_name
+    envid = coalesce(var.envid, var.env_name)
+    role  = "aenode"
+    color = "black"
+  }
 
-  static_nodes   = 1
-  spot_nodes     = 1
-  spot_nodes_min = 1
-  spot_nodes_max = 1
-
-  spot_price    = "0.04"
-  instance_type = "t3.large"
-  ami_name      = "aeternity-ubuntu-18.04-*"
-
-  additional_storage      = true
-  additional_storage_size = 5
-
-  enable_state_channels = true
-  enable_internal_api   = true
+  config_tags = {
+    bootstrap_version = var.bootstrap_version
+    vault_addr        = var.vault_addr
+    vault_role        = "ae-node"
+    node_config       = "secret/aenode/config/${var.env_name}"
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,5 @@
 variable "env" {}
 
-variable "envid" {
-  default = ""
-}
-
-variable "kind" {
-  default = ""
-}
-
-variable "color" {
-  default = "unknown"
-}
-
-variable "bootstrap_version" {}
-
 variable "spot_nodes" {
   default = 0
 }
@@ -34,12 +20,12 @@ variable "root_volume_size" {
 
 variable "root_volume_iops" {
   description = "Guaranteed minimum IOPS. 3000 is free tier"
-  default = 3000
+  default     = 3000
 }
 
 variable "root_volume_throughput" {
   description = "Number of megabytes per second limit. 125 is free tier"
-  default = 125
+  default     = 125
 }
 
 variable "additional_storage" {
@@ -63,18 +49,15 @@ variable "static_nodes" {
   default = 0
 }
 
-variable "instance_type" {}
+variable "instance_type" {
+  description = "Fleet insance type. Deprecated: Use instance_types."
+}
 
-variable "spot_price" {}
+variable "instance_types" {
+  type = list(string)
+}
 
 variable "ami_name" {}
-
-variable "vault_addr" {}
-
-variable "vault_role" {
-  type    = string
-  default = "ae-node"
-}
 
 variable "user_data_file" {
   default = "user_data.bash"
@@ -95,10 +78,6 @@ variable "asg_target_groups" {
   default = []
 }
 
-variable "node_config" {
-  default = ""
-}
-
 variable "vpc_id" {
   default = ""
 }
@@ -106,4 +85,12 @@ variable "vpc_id" {
 variable "subnets" {
   type    = list(any)
   default = []
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "config_tags" {
+  type = map(string)
 }


### PR DESCRIPTION
- update AWS provider version
- use launch templates instead of launch configuration
- unify tags module vairbales
- use TargetTrackingScaling instead of Simple (with alarms)
- use mixed instance policy for spot nodes
- allow configuration for multiple instances for capacity optimized strategy